### PR TITLE
Feature/add hpa config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ old_docs_temp_dir/
 .vscode/launch.json
 .vscode/settings.json
 
+## IntelliJ
+*.iml
+.idea

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -338,6 +338,12 @@
 |gatewayProxies.NAME.failover.nodePort|uint||(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.NAME.failover.secretName|string||(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.NAME.disabled|bool||Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.NAME.horizontalPodAutoscaler.apiVersion|string||accepts autoscaling/v1 or autoscaling/v2beta2.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.minReplicas|int32||minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.maxReplicas|int32||maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.targetCPUUtilizationPercentage|int32||target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1|
+|gatewayProxies.NAME.horizontalPodAutoscaler.metrics[].NAME|interface||metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2|
+|gatewayProxies.NAME.horizontalPodAutoscaler.behavior.NAME|interface||behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].value|string|||
@@ -464,6 +470,12 @@
 |gatewayProxies.gatewayProxy.failover.nodePort|uint|0|(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.gatewayProxy.failover.secretName|string|failover-downstream|(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.gatewayProxy.disabled|bool|false|Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.apiVersion|string||accepts autoscaling/v1 or autoscaling/v2beta2.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.minReplicas|int32||minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.maxReplicas|int32||maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.targetCPUUtilizationPercentage|int32||target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.metrics[].NAME|interface||metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.behavior.NAME|interface||behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2|
 |ingress.enabled|bool|false||
 |ingress.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |ingress.deployment.image.repository|string|ingress|image name (repository) for the container.|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -601,5 +601,13 @@
 |global.glooMtls.envoy.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|
 |global.glooMtls.envoy.image.pullPolicy|string||image pull policy for the container|
 |global.glooMtls.envoy.image.pullSecret|string||image pull policy for the container |
+|global.glooMtls.envoySidecarResources.limits.memory|string||amount of memory|
+|global.glooMtls.envoySidecarResources.limits.cpu|string||amount of CPUs|
+|global.glooMtls.envoySidecarResources.requests.memory|string||amount of memory|
+|global.glooMtls.envoySidecarResources.requests.cpu|string||amount of CPUs|
+|global.glooMtls.sdsResources.limits.memory|string||amount of memory|
+|global.glooMtls.sdsResources.limits.cpu|string||amount of CPUs|
+|global.glooMtls.sdsResources.requests.memory|string||amount of memory|
+|global.glooMtls.sdsResources.requests.cpu|string||amount of CPUs|
 |global.istioSDS.enabled|bool|false||
 |global.istioSDS.customSidecars[]|interface||Override the default Istio sidecar in gateway-proxy with a custom container. Ignored if IstioSDS.enabled is false|

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.3-OPENET"
+	chart.Version = "1.5.4-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.4-OPENET-SNAPSHOT"
+	chart.Version = "1.5.4-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -244,6 +244,7 @@ type GatewayProxy struct {
 	LoopBackAddress                string                       `json:"loopBackAddress,omitempty" desc:"Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1"`
 	Failover                       Failover                     `json:"failover" desc:"(Enterprise Only): Failover configuration"`
 	Disabled                       bool                         `json:"disabled,omitempty" desc:"Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations"`
+	HorizontalPodAutoscaler        *HorizontalPodAutoscaler     `json:"horizontalPodAutoscaler,omitempty" desc:"HorizontalPodAutoscaler for the GatewayProxy. Used only when Kind is set to Deployment. Resources must be set on the gateway-proxy deployment for HorizontalPodAutoscalers to function correctly"`
 }
 
 type GatewayProxyGatewaySettings struct {
@@ -261,6 +262,15 @@ type GatewayProxyKind struct {
 }
 type GatewayProxyDeployment struct {
 	*DeploymentSpecSansResources
+}
+
+type HorizontalPodAutoscaler struct {
+	ApiVersion                        string                   `json:"apiVersion,omitempty" desc:"accepts autoscaling/v1 or autoscaling/v2beta2."`
+	MinReplicas                       int32                    `json:"minReplicas,omitempty" desc:"minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down."`
+	MaxReplicas                       int32                    `json:"maxReplicas,omitempty" desc:"maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas."`
+	TargetCPUUtilizationPercentage    int32                    `json:"targetCPUUtilizationPercentage,omitempty" desc:"target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1"`
+	Metrics                           []map[string]interface{} `json:"metrics,omitempty" desc:"metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2"`
+	Behavior                          map[string]interface{}   `json:"behavior,omitempty" desc:"behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2"`
 }
 
 type DaemonSetSpec struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -401,9 +401,11 @@ type Stats struct {
 }
 
 type Mtls struct {
-	Enabled      bool                  `json:"enabled" desc:"Enables internal mtls authentication"`
-	Sds          SdsContainer          `json:"sds,omitempty"`
-	EnvoySidecar EnvoySidecarContainer `json:"envoy,omitempty"`
+	Enabled               bool                  `json:"enabled" desc:"Enables internal mtls authentication"`
+	Sds                   SdsContainer          `json:"sds,omitempty"`
+	EnvoySidecar          EnvoySidecarContainer `json:"envoy,omitempty"`
+	EnvoySidecarResources *ResourceRequirements `json:"envoySidecarResources,omitempty" desc:"Sets default resource requirements for all envoy sidecar containers."`
+	SdsResources          *ResourceRequirements `json:"sdsResources,omitempty" desc:"Sets default resource requirements for all sds containers."`
 }
 
 type SdsContainer struct {

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -84,6 +84,10 @@ spec:
         - mountPath: /etc/envoy/ssl
           name: gloo-mtls-certs
           readOnly: true
+{{- if .Values.global.glooMtls.envoySidecarResources }}
+        resources:
+{{ toYaml .Values.global.glooMtls.envoySidecarResources | indent 10 }}
+{{- end }}
       - name: sds
         image: {{ template "gloo.image" $sdsImage }}
         imagePullPolicy: {{ $sdsImage.pullPolicy }}
@@ -99,6 +103,10 @@ spec:
         - mountPath: /etc/envoy/ssl
           name: gloo-mtls-certs
           readOnly: true
+{{- if .Values.global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml .Values.global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
 {{- end }}
       - image: {{template "gloo.image" $image }}
         imagePullPolicy: {{ $image.pullPolicy }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -5,7 +5,9 @@
 {{- $global := .Values.global }}
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}
 {{- $image = merge $spec.podTemplate.image $global.image }}
@@ -392,7 +394,7 @@ spec:
         - mountPath: /etc/istio-certs/
           name: istio-certs
         - mountPath: /var/run/secrets/tokens
-          name: istio-token 
+          name: istio-token
 {{- end}}
 {{- end}}
       volumes:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -3,6 +3,7 @@
 {{- end -}}
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
+{{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- $image := $spec.podTemplate.image }}
@@ -229,6 +230,10 @@ spec:
       - name: sds
         image: {{ template "gloo.image" $sdsImage }}
         imagePullPolicy: {{ $sdsImage.pullPolicy }}
+{{- if $global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml $global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
         env:
           - name: POD_NAME
             valueFrom:
@@ -292,6 +297,10 @@ spec:
 {{- if not $global.istioSDS.customSidecars }}
       - name: istio-proxy
         image: docker.io/istio/proxyv2:1.6.8
+{{- if $global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml $global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
         args:
         - proxy
         - sidecar

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -1,5 +1,7 @@
-{{- range $name, $spec := .Values.gatewayProxies }}
-{{- if $spec.gatewaySettings}}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if and $spec.gatewaySettings (not $spec.disabled) }}
 {{$gatewaySettings := $spec.gatewaySettings}}
 {{- if not $gatewaySettings.disableGeneratedGateways}}
 

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.gateway.enabled }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if $spec.kind.deployment}}
+{{- if $spec.horizontalPodAutoscaler }}
+---
+apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: gloo
+    gloo: gateway-proxy
+    gateway-proxy-id: {{ $name | kebabcase }}
+  name: {{ $name | kebabcase }}-hpa
+  namespace: {{ $.Release.Namespace }}
+spec:
+  minReplicas: {{ $spec.horizontalPodAutoscaler.minReplicas }}
+  maxReplicas: {{ $spec.horizontalPodAutoscaler.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $name | kebabcase }}
+  {{- if (eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v1") }}
+  targetCPUUtilizationPercentage: {{ $spec.horizontalPodAutoscaler.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v2beta2" }}
+  metrics:
+  {{ toYaml $spec.horizontalPodAutoscaler.metrics | nindent 4 }}
+  {{- end }}
+  {{- if eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v2beta2" }}
+  behavior:
+  {{ toYaml $spec.horizontalPodAutoscaler.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.gateway.enabled }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if not $spec.disabled }}
 {{- $svcName := default $name $spec.service.name }}
 ---
 apiVersion: v1
@@ -80,5 +83,6 @@ spec:
   {{- end }} # with spec.service.loadBalancerSourceRanges
   {{- end }} # $spec.service.loadBalancerSourceRanges
   {{- end }} # $spec.service.type "LoadBalancer"
+{{- end }}
 {{- end }}
 {{ end }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -3,7 +3,10 @@
 {{- end -}}
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if not $spec.disabled }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 ---
 # config_map
@@ -353,5 +356,6 @@ data:
           address: {{ $spec.loopBackAddress }}
           port_value: 19000
 {{- else}}{{ toYaml $spec.configMap.data | indent 2}}{{- end}} # if (empty $spec.configMap.data) ## allows full custom
+{{- end }} {{/* - if not $spec.disabled */}}
 {{- end }} # range $name, $spec := .Values.gatewayProxies
 {{- end -}} # if .Values.gateway.enabled

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1843,6 +1843,74 @@ spec:
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
+					It("finds resources on all containers, with identical resources on all sds and sidecar containers", func() {
+                        envoySidecarVals := []string{"100Mi", "200m", "300Mi", "400m"}
+                        sdsVals := []string{"101Mi", "201m", "301Mi", "401m"}
+
+                        prepareMakefile(namespace, helmValues{
+                            valuesArgs: []string{
+                                "global.glooMtls.enabled=true", // adds gloo/gateway proxy side containers
+                                "global.istioSDS.enabled=true", // add default itsio sds sidecar
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.requests.memory=%s", envoySidecarVals[0]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.requests.cpu=%s", envoySidecarVals[1]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.limits.memory=%s", envoySidecarVals[2]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.limits.cpu=%s", envoySidecarVals[3]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.requests.memory=%s", sdsVals[0]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.requests.cpu=%s", sdsVals[1]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.limits.memory=%s", sdsVals[2]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.limits.cpu=%s", sdsVals[3]),
+                            },
+                        })
+
+                        // get all deployments for arbitrary examination/testing
+                        var deployments []*unstructured.Unstructured
+                        testManifest.SelectResources(func(unstructured *unstructured.Unstructured) bool {
+                            if unstructured.GetKind() == "Deployment" {
+                                deployments = append(deployments, unstructured)
+                            }
+                            return true
+                        })
+
+                        for _, deployment := range deployments {
+                            // marshall unstructured object into deployment
+                            rawDeploy, err := deployment.MarshalJSON()
+                            Expect(err).NotTo(HaveOccurred())
+                            deploy := appsv1.Deployment{}
+                            err = json.Unmarshal(rawDeploy, &deploy)
+                            Expect(err).NotTo(HaveOccurred())
+
+                            // look for sidecar and sds containers, then test their resource values.
+                            for _, container := range deploy.Spec.Template.Spec.Containers {
+                                // still make sure non-sds/sidecar containers have non-nil resources, since all
+                                // other containers should have default resources values set in their templates.
+                                Expect(container.Resources).NotTo(BeNil(), "deployment/container %s/%s had nil resources", deployment.GetName(), container.Name)
+                                if container.Name == "envoy-sidecar" || container.Name == "sds" || container.Name == "istio-proxy" {
+                                    var expectedVals = sdsVals
+                                    //istio-proxy is another sds container
+                                    if container.Name == "envoy-sidecar" {
+                                        expectedVals = envoySidecarVals
+                                    }
+
+                                    Expect(container.Resources.Requests.Memory().String()).To(Equal(expectedVals[0]),
+                                        "deployment/container %s/%s had incorrect request memory: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[0], container.Resources.Requests.Memory().String())
+
+                                    Expect(container.Resources.Requests.Cpu().String()).To(Equal(expectedVals[1]),
+                                        "deployment/container %s/%s had incorrect request cpu: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[1], container.Resources.Requests.Cpu().String())
+
+                                    Expect(container.Resources.Limits.Memory().String()).To(Equal(expectedVals[2]),
+                                        "deployment/container %s/%s had incorrect limit memory: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[2], container.Resources.Limits.Memory().String())
+
+                                    Expect(container.Resources.Limits.Cpu().String()).To(Equal(expectedVals[3]),
+                                        "deployment/container %s/%s had incorrect limit cpu: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[3], container.Resources.Limits.Cpu().String())
+                                }
+                            }
+                        }
+                    })
+
 					It("enable sts discovery", func() {
 						settings := makeUnstructured(`
 apiVersion: gloo.solo.io/v1


### PR DESCRIPTION
# Description

Add resources to SDS and Envoy Sidecar Resources. Add HPA definition for gateway-proxy.

This new feature can be used to configure HPA and default resources.

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works