### PR TITLE
Bugfix/fvg 9417 static upstream cause no healthy upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/solo-io/gloo
+module github.com/openet/gloo
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openet/gloo
+module github.com/solo-io/gloo
 
 go 1.14
 

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.4-OPENET"
+	chart.Version = "1.5.5-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -137,7 +137,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 		}
 
 		// fix issue where ipv6 addr cannot bind
-		out.DnsLookupFamily = envoyapi.Cluster_V4_ONLY
+		out.DnsLookupFamily = envoyapi.Cluster_AUTO
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Change envoyapi configuration to Cluster_AUTO to enable use of ipv6

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works