### PR TITLE
Fvg 9951 gateway and gloo pods not ready with mtls enabled in an ipv6 only k8s cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ old_docs_temp_dir/
 .vscode/launch.json
 .vscode/settings.json
 
+## IntelliJ
+*.iml
+.idea

--- a/changelog/v1.6.0-beta4/helm-pass-image-pull-secret.yaml
+++ b/changelog/v1.6.0-beta4/helm-pass-image-pull-secret.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/3729
+    description: >-
+      Add possibility to pass image pull secret to all deployments in helm chart

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -46,6 +46,22 @@
 |settings.integrations.knative.requireIngressClass|bool||only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'.|
 |settings.integrations.knative.extraKnativeInternalLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the knative internal deployment.|
 |settings.integrations.knative.extraKnativeExternalLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the knative external deployment.|
+|settings.integrations.consul.datacenter|string||Datacenter to use. If not provided, the default agent datacenter is used.|
+|settings.integrations.consul.username|string||Username to use for HTTP Basic Authentication.|
+|settings.integrations.consul.password|string||Password to use for HTTP Basic Authentication.|
+|settings.integrations.consul.token|string||Token is used to provide a per-request ACL token which overrides the agent's default token.|
+|settings.integrations.consul.caFile|string||caFile is the optional path to the CA certificate used for Consul communication, defaults to the system bundle if not specified.|
+|settings.integrations.consul.caPath|string||caPath is the optional path to a directory of CA certificates to use for Consul communication, defaults to the system bundle if not specified.|
+|settings.integrations.consul.certFile|string||CertFile is the optional path to the certificate for Consul communication. If this is set then you need to also set KeyFile.|
+|settings.integrations.consul.keyFile|string||KeyFile is the optional path to the private key for Consul communication. If this is set then you need to also set CertFile.|
+|settings.integrations.consul.insecureSkipVerify|bool||InsecureSkipVerify if set to true will disable TLS host verification.|
+|settings.integrations.consul.waitTime.seconds|int32||The value of this duration in seconds.|
+|settings.integrations.consul.waitTime.nanos|int32||The value of this duration in nanoseconds.|
+|settings.integrations.consul.serviceDiscovery.dataCenters[]|string||Use this parameter to restrict the data centers that will be considered when discovering and routing to services. If not provided, Gloo will use all available data centers.|
+|settings.integrations.consul.httpAddress|string||The address of the Consul HTTP server. Used by service discovery and key-value storage (if-enabled). Defaults to the value of the standard CONSUL_HTTP_ADDR env if set, otherwise to 127.0.0.1:8500.|
+|settings.integrations.consul.dnsAddress|string||The address of the DNS server used to resolve hostnames in the Consul service address. Used by service discovery (required when Consul service instances are stored as DNS names). Defaults to 127.0.0.1:8600. (the default Consul DNS server)|
+|settings.integrations.consul.dnsPollingInterval.seconds|int32||The value of this duration in seconds.|
+|settings.integrations.consul.dnsPollingInterval.nanos|int32||The value of this duration in nanoseconds.|
 |settings.create|bool|true|create a Settings CRD which provides bootstrap configuration to Gloo controllers|
 |settings.extensions|interface|||
 |settings.singleNamespace|bool|false|Enable to use install namespace as WatchNamespace and WriteNamespace|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -425,8 +425,8 @@
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are preferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||
-|gatewayProxies.gatewayProxy.rateLimitSettings.max_tokens|int|||
-|gatewayProxies.gatewayProxy.rateLimitSettings.fill_rate|double|||
+|gatewayProxies.gatewayProxy.dynamicResources.adsConfig.rateLimitSettings.max_tokens|int||Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a default value of 100 will be used.|
+|gatewayProxies.gatewayProxy.dynamicResources.adsConfig.rateLimitSettings.fill_rate|double||Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens per second will be used.|
 |gatewayProxies.gatewayProxy.gatewaySettings.disableGeneratedGateways|bool|false|set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.gatewayProxy.gatewaySettings.ipv4Only|bool|false|set to true if your network allows ipv4 addresses only. Sets the Gateway spec's bindAddress to 0.0.0.0 instead of ::|
 |gatewayProxies.gatewayProxy.gatewaySettings.useProxyProto|bool|false|use proxy protocol|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -338,6 +338,12 @@
 |gatewayProxies.NAME.failover.nodePort|uint||(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.NAME.failover.secretName|string||(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.NAME.disabled|bool||Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.NAME.horizontalPodAutoscaler.apiVersion|string||accepts autoscaling/v1 or autoscaling/v2beta2.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.minReplicas|int32||minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.maxReplicas|int32||maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.|
+|gatewayProxies.NAME.horizontalPodAutoscaler.targetCPUUtilizationPercentage|int32||target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1|
+|gatewayProxies.NAME.horizontalPodAutoscaler.metrics[].NAME|interface||metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2|
+|gatewayProxies.NAME.horizontalPodAutoscaler.behavior.NAME|interface||behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].value|string|||
@@ -464,6 +470,12 @@
 |gatewayProxies.gatewayProxy.failover.nodePort|uint|0|(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.gatewayProxy.failover.secretName|string|failover-downstream|(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.gatewayProxy.disabled|bool|false|Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.apiVersion|string||accepts autoscaling/v1 or autoscaling/v2beta2.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.minReplicas|int32||minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.maxReplicas|int32||maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.targetCPUUtilizationPercentage|int32||target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.metrics[].NAME|interface||metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2|
+|gatewayProxies.gatewayProxy.horizontalPodAutoscaler.behavior.NAME|interface||behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2|
 |ingress.enabled|bool|false||
 |ingress.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |ingress.deployment.image.repository|string|ingress|image name (repository) for the container.|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -425,8 +425,8 @@
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are preferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||
-|gatewayProxies.gatewayProxy.rate_limit_settings.max_tokens|int|||
-|gatewayProxies.gatewayProxy.rate_limit_settings.fill_rate|double|||
+|gatewayProxies.gatewayProxy.rateLimitSettings.max_tokens|int|||
+|gatewayProxies.gatewayProxy.rateLimitSettings.fill_rate|double|||
 |gatewayProxies.gatewayProxy.gatewaySettings.disableGeneratedGateways|bool|false|set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.gatewayProxy.gatewaySettings.ipv4Only|bool|false|set to true if your network allows ipv4 addresses only. Sets the Gateway spec's bindAddress to 0.0.0.0 instead of ::|
 |gatewayProxies.gatewayProxy.gatewaySettings.useProxyProto|bool|false|use proxy protocol|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -425,6 +425,8 @@
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are preferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||
+|gatewayProxies.gatewayProxy.rate_limit_settings.max_tokens|int|||
+|gatewayProxies.gatewayProxy.rate_limit_settings.fill_rate|double|||
 |gatewayProxies.gatewayProxy.gatewaySettings.disableGeneratedGateways|bool|false|set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.gatewayProxy.gatewaySettings.ipv4Only|bool|false|set to true if your network allows ipv4 addresses only. Sets the Gateway spec's bindAddress to 0.0.0.0 instead of ::|
 |gatewayProxies.gatewayProxy.gatewaySettings.useProxyProto|bool|false|use proxy protocol|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -425,8 +425,8 @@
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are preferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||
-|gatewayProxies.gatewayProxy.dynamicResources.adsConfig.rateLimitSettings.max_tokens|int||Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a default value of 100 will be used.|
-|gatewayProxies.gatewayProxy.dynamicResources.adsConfig.rateLimitSettings.fill_rate|double||Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens per second will be used.|
+|gatewayProxies.gatewayProxy.xdsConfig.rateLimitSettings.max_tokens|int||Maximum number of tokens to be used for rate limiting discovery request calls. If not set, a default value of 100 will be used.|
+|gatewayProxies.gatewayProxy.xdsConfig.rateLimitSettings.fill_rate|double||Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens per second will be used.|
 |gatewayProxies.gatewayProxy.gatewaySettings.disableGeneratedGateways|bool|false|set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.gatewayProxy.gatewaySettings.ipv4Only|bool|false|set to true if your network allows ipv4 addresses only. Sets the Gateway spec's bindAddress to 0.0.0.0 instead of ::|
 |gatewayProxies.gatewayProxy.gatewaySettings.useProxyProto|bool|false|use proxy protocol|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -97,6 +97,7 @@
 |gloo.deployment.resources.limits.cpu|string||amount of CPUs|
 |gloo.deployment.resources.requests.memory|string||amount of memory|
 |gloo.deployment.resources.requests.cpu|string||amount of CPUs|
+|gloo.deployment.nodeSelector.NAME|string||label selector for nodes|
 |gloo.serviceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
 |gloo.serviceAccount.disableAutomount|bool|false|disable automunting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|
 |discovery.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
@@ -133,6 +134,7 @@
 |discovery.deployment.resources.limits.cpu|string||amount of CPUs|
 |discovery.deployment.resources.requests.memory|string||amount of memory|
 |discovery.deployment.resources.requests.cpu|string||amount of CPUs|
+|discovery.deployment.nodeSelector.NAME|string||label selector for nodes|
 |discovery.fdsMode|string|WHITELIST|mode for function discovery (blacklist or whitelist). See more info in the settings docs|
 |discovery.enabled|bool|true|enable Discovery features|
 |discovery.serviceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
@@ -177,6 +179,7 @@
 |gateway.deployment.resources.limits.cpu|string||amount of CPUs|
 |gateway.deployment.resources.requests.memory|string||amount of memory|
 |gateway.deployment.resources.requests.cpu|string||amount of CPUs|
+|gateway.deployment.nodeSelector.NAME|string||label selector for nodes|
 |gateway.certGenJob.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gateway.certGenJob.image.repository|string|certgen|image name (repository) for the container.|
 |gateway.certGenJob.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|
@@ -188,6 +191,7 @@
 |gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.certGenJob.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gateway.certGenJob.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
+|gateway.certGenJob.nodeSelector.NAME|string||label selector for nodes|
 |gateway.updateValues|bool|false|if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
 |gateway.proxyServiceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
 |gateway.proxyServiceAccount.disableAutomount|bool|false|disable automunting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -601,5 +601,13 @@
 |global.glooMtls.envoy.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|
 |global.glooMtls.envoy.image.pullPolicy|string||image pull policy for the container|
 |global.glooMtls.envoy.image.pullSecret|string||image pull policy for the container |
+|global.glooMtls.envoySidecarResources.limits.memory|string||amount of memory|
+|global.glooMtls.envoySidecarResources.limits.cpu|string||amount of CPUs|
+|global.glooMtls.envoySidecarResources.requests.memory|string||amount of memory|
+|global.glooMtls.envoySidecarResources.requests.cpu|string||amount of CPUs|
+|global.glooMtls.sdsResources.limits.memory|string||amount of memory|
+|global.glooMtls.sdsResources.limits.cpu|string||amount of CPUs|
+|global.glooMtls.sdsResources.requests.memory|string||amount of memory|
+|global.glooMtls.sdsResources.requests.cpu|string||amount of CPUs|
 |global.istioSDS.enabled|bool|false||
 |global.istioSDS.customSidecars[]|interface||Override the default Istio sidecar in gateway-proxy with a custom container. Ignored if IstioSDS.enabled is false|

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/solo-io/gloo
+module github.com/openet/gloo
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openet/gloo
+module github.com/solo-io/gloo
 
 go 1.14
 

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.1-OPENET-SNAPSHOT"
+	chart.Version = "1.5.1-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.3-OPENET"
+	chart.Version = "1.5.4-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.0-OPENET"
+	chart.Version = "1.5.1-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.4-OPENET"
+	chart.Version = "1.5.5-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.2-OPENET"
+	chart.Version = "1.5.3-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.1-OPENET"
+	chart.Version = "1.5.2-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.3-OPENET"
+	chart.Version = "1.5.3-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.6-OPENET-SNAPSHOT"
+	chart.Version = "1.5.6-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.5-OPENET"
+	chart.Version = "1.5.6-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.3-OPENET-SNAPSHOT"
+	chart.Version = "1.5.3-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.2-OPENET-SNAPSHOT"
+	chart.Version = "1.5.2-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = version
+	chart.Version = "1.5.0-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.6-OPENET"
+	chart.Version = "1.5.6-OPENET-SNAPSHOT"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.4-OPENET-SNAPSHOT"
+	chart.Version = "1.5.4-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -244,6 +244,7 @@ type GatewayProxy struct {
 	LoopBackAddress                string                       `json:"loopBackAddress,omitempty" desc:"Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1"`
 	Failover                       Failover                     `json:"failover" desc:"(Enterprise Only): Failover configuration"`
 	Disabled                       bool                         `json:"disabled,omitempty" desc:"Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations"`
+	HorizontalPodAutoscaler        *HorizontalPodAutoscaler     `json:"horizontalPodAutoscaler,omitempty" desc:"HorizontalPodAutoscaler for the GatewayProxy. Used only when Kind is set to Deployment. Resources must be set on the gateway-proxy deployment for HorizontalPodAutoscalers to function correctly"`
 }
 
 type GatewayProxyGatewaySettings struct {
@@ -261,6 +262,15 @@ type GatewayProxyKind struct {
 }
 type GatewayProxyDeployment struct {
 	*DeploymentSpecSansResources
+}
+
+type HorizontalPodAutoscaler struct {
+	ApiVersion                        string                   `json:"apiVersion,omitempty" desc:"accepts autoscaling/v1 or autoscaling/v2beta2."`
+	MinReplicas                       int32                    `json:"minReplicas,omitempty" desc:"minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down."`
+	MaxReplicas                       int32                    `json:"maxReplicas,omitempty" desc:"maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas."`
+	TargetCPUUtilizationPercentage    int32                    `json:"targetCPUUtilizationPercentage,omitempty" desc:"target average CPU utilization (represented as a percentage of requested CPU) over all the pods. Used only with apiVersion autoscaling/v1"`
+	Metrics                           []map[string]interface{} `json:"metrics,omitempty" desc:"metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used). Used only with apiVersion autoscaling/v2beta2"`
+	Behavior                          map[string]interface{}   `json:"behavior,omitempty" desc:"behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). Used only with apiVersion autoscaling/v2beta2"`
 }
 
 type DaemonSetSpec struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -401,9 +401,11 @@ type Stats struct {
 }
 
 type Mtls struct {
-	Enabled      bool                  `json:"enabled" desc:"Enables internal mtls authentication"`
-	Sds          SdsContainer          `json:"sds,omitempty"`
-	EnvoySidecar EnvoySidecarContainer `json:"envoy,omitempty"`
+	Enabled               bool                  `json:"enabled" desc:"Enables internal mtls authentication"`
+	Sds                   SdsContainer          `json:"sds,omitempty"`
+	EnvoySidecar          EnvoySidecarContainer `json:"envoy,omitempty"`
+	EnvoySidecarResources *ResourceRequirements `json:"envoySidecarResources,omitempty" desc:"Sets default resource requirements for all envoy sidecar containers."`
+	SdsResources          *ResourceRequirements `json:"sdsResources,omitempty" desc:"Sets default resource requirements for all sds containers."`
 }
 
 type SdsContainer struct {

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end}}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: gloo
       volumes:
 {{- if .Values.global.glooMtls.enabled }}
@@ -171,7 +172,3 @@ spec:
           periodSeconds: 2
           failureThreshold: 10
 {{- end }}
-      {{- if $image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ $image.pullSecret }}
-      {{- end}}

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -84,6 +84,10 @@ spec:
         - mountPath: /etc/envoy/ssl
           name: gloo-mtls-certs
           readOnly: true
+{{- if .Values.global.glooMtls.envoySidecarResources }}
+        resources:
+{{ toYaml .Values.global.glooMtls.envoySidecarResources | indent 10 }}
+{{- end }}
       - name: sds
         image: {{ template "gloo.image" $sdsImage }}
         imagePullPolicy: {{ $sdsImage.pullPolicy }}
@@ -99,6 +103,10 @@ spec:
         - mountPath: /etc/envoy/ssl
           name: gloo-mtls-certs
           readOnly: true
+{{- if .Values.global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml .Values.global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
 {{- end }}
       - image: {{template "gloo.image" $image }}
         imagePullPolicy: {{ $image.pullPolicy }}

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -172,3 +172,7 @@ spec:
           periodSeconds: 2
           failureThreshold: 10
 {{- end }}
+{{- with .Values.gloo.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       securityContext:
         runAsNonRoot: true
         {{- if not .Values.ingress.deployment.floatingUserId }}

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       {{- end }}
 {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       containers:
       - args: ["--disable-hot-restart"]
         env:
@@ -75,9 +76,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/envoy
           name: envoy-config
-      {{- if $image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ $image.pullSecret }}{{end}}
       volumes:
       - configMap:
           name: ingress-envoy-config

--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -36,7 +36,10 @@ spec:
       enableCredentialsDiscovey: true
 {{- end }}
 
-
+  {{- if .Values.settings.integrations.consul }}
+  consul:
+  {{- toYaml .Values.settings.integrations.consul | nindent 4 }}
+  {{- end }}
 
 {{- if .Values.settings.writeNamespace }}
   discoveryNamespace: {{ .Values.settings.writeNamespace }}

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         gloo: gloo-mtls-certs
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: certgen
       containers:
         - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.global.glooMtls.enabled }}
 ---
+{{- $bindAddr := ternary "::" "0.0.0.0" .Values.ipv6Enabled | quote -}}
 # config_map
 apiVersion: v1
 kind: ConfigMap
@@ -17,7 +18,7 @@ data:
     static_resources:
       listeners:
       - name: envoy_xds_mtls_listener
-        address: { socket_address: { address: "0.0.0.0", port_value: {{ .Values.gloo.deployment.xdsPort }} } }
+        address: { socket_address: { address: {{ $bindAddr }}, port_value: {{ .Values.gloo.deployment.xdsPort }} } }
         filter_chains:
         - filters:
           - name: envoy.filters.network.tcp_proxy
@@ -47,7 +48,7 @@ data:
                       - envoy_grpc:
                           cluster_name: gloo_sds
       - name: envoy_rest_xds_mtls_listener
-        address: { socket_address: { address: "0.0.0.0", port_value: {{ .Values.gloo.deployment.restXdsPort }} } }
+        address: { socket_address: { address: {{ $bindAddr }}, port_value: {{ .Values.gloo.deployment.restXdsPort }} } }
         filter_chains:
         - filters:
           - name: envoy.filters.network.tcp_proxy

--- a/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end}}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: discovery
       containers:
       - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -69,4 +69,9 @@ spec:
       # Pod security context
       securityContext:
         fsGroup: {{ printf "%.0f" (float64 .Values.discovery.deployment.fsGroup) }}
+{{- with .Values.discovery.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
 {{- end }}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end}}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: gateway
       containers:
       - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -95,3 +95,8 @@ spec:
             secretName: {{ .Values.gateway.validation.secretName }}
 {{- end}}
 {{- end }}
+
+{{- with .Values.gateway.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -94,9 +94,9 @@ spec:
             defaultMode: 420
             secretName: {{ .Values.gateway.validation.secretName }}
 {{- end}}
-{{- end }}
-
 {{- with .Values.gateway.deployment.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
+{{- end }}
+
 {{- end }}

--- a/install/helm/gloo/templates/6-access-logger-deployment.yaml
+++ b/install/helm/gloo/templates/6-access-logger-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: gateway-proxy
       securityContext:
         runAsNonRoot: true

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -43,6 +43,10 @@ spec:
             - "--svc-name=gateway"
             - "--validating-webhook-configuration-name=gloo-gateway-validation-webhook-{{ .Release.Namespace }}"
       restartPolicy: {{ .Values.gateway.certGenJob.restartPolicy }}
+{{- with .Values.gateway.certGenJob.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
   # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
   # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...
   # if the feature flag is not enabled in the k8s api server, this setting will be silently ignored at creation time

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         gloo: gateway-certgen
     spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: certgen
       containers:
         - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -5,7 +5,9 @@
 {{- $global := .Values.global }}
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}
 {{- $image = merge $spec.podTemplate.image $global.image }}
@@ -392,7 +394,7 @@ spec:
         - mountPath: /etc/istio-certs/
           name: istio-certs
         - mountPath: /var/run/secrets/tokens
-          name: istio-token 
+          name: istio-token
 {{- end}}
 {{- end}}
       volumes:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -96,6 +96,7 @@ spec:
               topologyKey: kubernetes.io/hostname
 {{- end}}
 {{- end}}
+      {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: gateway-proxy
       {{- if $spec.extraInitContainersHelper }}
       initContainers:
@@ -281,9 +282,6 @@ spec:
       tolerations:
 {{ toYaml $spec.podTemplate.tolerations | indent 6}}
       {{- end }}
-      {{- if $image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ $image.pullSecret }}{{end}}
       {{- if $spec.podTemplate.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ $spec.podTemplate.terminationGracePeriodSeconds }}
       {{- end }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -3,6 +3,7 @@
 {{- end -}}
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
+{{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- $image := $spec.podTemplate.image }}
@@ -229,6 +230,10 @@ spec:
       - name: sds
         image: {{ template "gloo.image" $sdsImage }}
         imagePullPolicy: {{ $sdsImage.pullPolicy }}
+{{- if $global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml $global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
         env:
           - name: POD_NAME
             valueFrom:
@@ -292,6 +297,10 @@ spec:
 {{- if not $global.istioSDS.customSidecars }}
       - name: istio-proxy
         image: docker.io/istio/proxyv2:1.6.8
+{{- if $global.glooMtls.sdsResources }}
+        resources:
+{{ toYaml $global.glooMtls.sdsResources | indent 10 }}
+{{- end }}
         args:
         - proxy
         - sidecar

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -1,5 +1,7 @@
-{{- range $name, $spec := .Values.gatewayProxies }}
-{{- if $spec.gatewaySettings}}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if and $spec.gatewaySettings (not $spec.disabled) }}
 {{$gatewaySettings := $spec.gatewaySettings}}
 {{- if not $gatewaySettings.disableGeneratedGateways}}
 

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.gateway.enabled }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if $spec.kind.deployment}}
+{{- if $spec.horizontalPodAutoscaler }}
+---
+apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: gloo
+    gloo: gateway-proxy
+    gateway-proxy-id: {{ $name | kebabcase }}
+  name: {{ $name | kebabcase }}-hpa
+  namespace: {{ $.Release.Namespace }}
+spec:
+  minReplicas: {{ $spec.horizontalPodAutoscaler.minReplicas }}
+  maxReplicas: {{ $spec.horizontalPodAutoscaler.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $name | kebabcase }}
+  {{- if (eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v1") }}
+  targetCPUUtilizationPercentage: {{ $spec.horizontalPodAutoscaler.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v2beta2" }}
+  metrics:
+  {{ toYaml $spec.horizontalPodAutoscaler.metrics | nindent 4 }}
+  {{- end }}
+  {{- if eq $spec.horizontalPodAutoscaler.apiVersion "autoscaling/v2beta2" }}
+  behavior:
+  {{ toYaml $spec.horizontalPodAutoscaler.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.gateway.enabled }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if not $spec.disabled }}
 {{- $svcName := default $name $spec.service.name }}
 ---
 apiVersion: v1
@@ -80,5 +83,6 @@ spec:
   {{- end }} # with spec.service.loadBalancerSourceRanges
   {{- end }} # $spec.service.loadBalancerSourceRanges
   {{- end }} # $spec.service.type "LoadBalancer"
+{{- end }}
 {{- end }}
 {{ end }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -334,9 +334,11 @@ data:
     dynamic_resources:
       ads_config:
         api_type: GRPC
-        {{- with $spec.rate_limit_settings }}
+        {{- with $spec.rateLimitSettings }}
         rate_limit_settings:
-          {{ toYaml . }}
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
         {{- end }}
         grpc_services:
         - envoy_grpc: {cluster_name: gloo.{{ $.Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}:{{ $.Values.gloo.deployment.xdsPort }}}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -334,7 +334,7 @@ data:
     dynamic_resources:
       ads_config:
         api_type: GRPC
-        {{- with $spec.rateLimitSettings }}
+        {{- with $spec.dynamicResources.adsConfig.rateLimitSettings }}
         rate_limit_settings:
         {{- range $key, $value := . }}
           {{ $key }}: {{ $value }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -334,7 +334,7 @@ data:
     dynamic_resources:
       ads_config:
         api_type: GRPC
-        {{- with $spec.dynamicResources.adsConfig.rateLimitSettings }}
+        {{- with $spec.xdsConfig.rateLimitSettings }}
         rate_limit_settings:
         {{- range $key, $value := . }}
           {{ $key }}: {{ $value }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -334,7 +334,10 @@ data:
     dynamic_resources:
       ads_config:
         api_type: GRPC
-        rate_limit_settings: {}
+        {{- with $spec.rate_limit_settings }}
+        rate_limit_settings:
+          {{ toYaml . | indent 10 }}
+        {{- end }}
         grpc_services:
         - envoy_grpc: {cluster_name: gloo.{{ $.Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}:{{ $.Values.gloo.deployment.xdsPort }}}
       cds_config:

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -336,7 +336,7 @@ data:
         api_type: GRPC
         {{- with $spec.rate_limit_settings }}
         rate_limit_settings:
-          {{ toYaml . | indent 10 }}
+          {{ toYaml . }}
         {{- end }}
         grpc_services:
         - envoy_grpc: {cluster_name: gloo.{{ $.Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}:{{ $.Values.gloo.deployment.xdsPort }}}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -3,7 +3,10 @@
 {{- end -}}
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
+{{- if not $spec.disabled }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 ---
 # config_map
@@ -353,5 +356,6 @@ data:
           address: {{ $spec.loopBackAddress }}
           port_value: 19000
 {{- else}}{{ toYaml $spec.configMap.data | indent 2}}{{- end}} # if (empty $spec.configMap.data) ## allows full custom
+{{- end }} {{/* - if not $spec.disabled */}}
 {{- end }} # range $name, $spec := .Values.gatewayProxies
 {{- end -}} # if .Values.gateway.enabled

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -1,8 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-
 
 {{- define "gloo.roleKind" -}}
 {{- if .Values.global.glooRbac.namespaced -}}
@@ -37,5 +33,12 @@ Get the wasm version of the image.
 {{ .registry }}/{{ .repository }}:{{ regexReplaceAll "([0-9]+\\.[0-9]+\\.[0-9]+)" .tag "${1}-wasm" }}
 {{- else -}}
 {{ .registry }}/{{ .repository }}:wasm-{{ .tag }}
+{{- end -}}
+{{- end -}}
+
+{{- define "gloo.pullSecret" -}}
+{{- if .pullSecret -}}
+imagePullSecrets:
+- name: {{ .pullSecret }}
 {{- end -}}
 {{- end -}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1843,6 +1843,74 @@ spec:
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
+					It("finds resources on all containers, with identical resources on all sds and sidecar containers", func() {
+                        envoySidecarVals := []string{"100Mi", "200m", "300Mi", "400m"}
+                        sdsVals := []string{"101Mi", "201m", "301Mi", "401m"}
+
+                        prepareMakefile(namespace, helmValues{
+                            valuesArgs: []string{
+                                "global.glooMtls.enabled=true", // adds gloo/gateway proxy side containers
+                                "global.istioSDS.enabled=true", // add default itsio sds sidecar
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.requests.memory=%s", envoySidecarVals[0]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.requests.cpu=%s", envoySidecarVals[1]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.limits.memory=%s", envoySidecarVals[2]),
+                                fmt.Sprintf("global.glooMtls.envoySidecarResources.limits.cpu=%s", envoySidecarVals[3]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.requests.memory=%s", sdsVals[0]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.requests.cpu=%s", sdsVals[1]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.limits.memory=%s", sdsVals[2]),
+                                fmt.Sprintf("global.glooMtls.sdsResources.limits.cpu=%s", sdsVals[3]),
+                            },
+                        })
+
+                        // get all deployments for arbitrary examination/testing
+                        var deployments []*unstructured.Unstructured
+                        testManifest.SelectResources(func(unstructured *unstructured.Unstructured) bool {
+                            if unstructured.GetKind() == "Deployment" {
+                                deployments = append(deployments, unstructured)
+                            }
+                            return true
+                        })
+
+                        for _, deployment := range deployments {
+                            // marshall unstructured object into deployment
+                            rawDeploy, err := deployment.MarshalJSON()
+                            Expect(err).NotTo(HaveOccurred())
+                            deploy := appsv1.Deployment{}
+                            err = json.Unmarshal(rawDeploy, &deploy)
+                            Expect(err).NotTo(HaveOccurred())
+
+                            // look for sidecar and sds containers, then test their resource values.
+                            for _, container := range deploy.Spec.Template.Spec.Containers {
+                                // still make sure non-sds/sidecar containers have non-nil resources, since all
+                                // other containers should have default resources values set in their templates.
+                                Expect(container.Resources).NotTo(BeNil(), "deployment/container %s/%s had nil resources", deployment.GetName(), container.Name)
+                                if container.Name == "envoy-sidecar" || container.Name == "sds" || container.Name == "istio-proxy" {
+                                    var expectedVals = sdsVals
+                                    //istio-proxy is another sds container
+                                    if container.Name == "envoy-sidecar" {
+                                        expectedVals = envoySidecarVals
+                                    }
+
+                                    Expect(container.Resources.Requests.Memory().String()).To(Equal(expectedVals[0]),
+                                        "deployment/container %s/%s had incorrect request memory: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[0], container.Resources.Requests.Memory().String())
+
+                                    Expect(container.Resources.Requests.Cpu().String()).To(Equal(expectedVals[1]),
+                                        "deployment/container %s/%s had incorrect request cpu: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[1], container.Resources.Requests.Cpu().String())
+
+                                    Expect(container.Resources.Limits.Memory().String()).To(Equal(expectedVals[2]),
+                                        "deployment/container %s/%s had incorrect limit memory: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[2], container.Resources.Limits.Memory().String())
+
+                                    Expect(container.Resources.Limits.Cpu().String()).To(Equal(expectedVals[3]),
+                                        "deployment/container %s/%s had incorrect limit cpu: expected %s, got %s",
+                                        deployment.GetName(), container.Name, expectedVals[3], container.Resources.Limits.Cpu().String())
+                                }
+                            }
+                        }
+                    })
+
 					It("enable sts discovery", func() {
 						settings := makeUnstructured(`
 apiVersion: gloo.solo.io/v1

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1513,6 +1513,44 @@ var _ = Describe("Helm Test", func() {
 							gatewayProxyDeployment.GetNamespace(),
 							gatewayProxyDeployment.GetName()).To(BeNil())
 					})
+
+					Context("pass image pull secrets", func() {
+						pullSecretName := "test-pull-secret"
+						pullSecret := []v1.LocalObjectReference{
+							{Name: pullSecretName},
+						}
+
+						It("via global values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("global.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayProxyDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+						})
+
+						It("via podTemplate values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("gatewayProxies.gatewayProxy.podTemplate.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayProxyDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+						})
+
+						It("podTemplate values win over global", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									"global.image.pullSecret=wrong",
+									fmt.Sprintf("gatewayProxies.gatewayProxy.podTemplate.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayProxyDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+						})
+					})
 				})
 
 				Context("gateway validation resources", func() {
@@ -2293,6 +2331,44 @@ metadata:
 						})
 						testManifest.ExpectDeploymentAppsV1(glooDeployment)
 					})
+
+					Context("pass image pull secrets", func() {
+						pullSecretName := "test-pull-secret"
+						pullSecret := []v1.LocalObjectReference{
+							{Name: pullSecretName},
+						}
+
+						It("via global values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("global.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							glooDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(glooDeployment)
+						})
+
+						It("via podTemplate values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("gloo.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							glooDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(glooDeployment)
+						})
+
+						It("podTemplate values win over global", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									"global.image.pullSecret=wrong",
+									fmt.Sprintf("gloo.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							glooDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(glooDeployment)
+						})
+					})
 				})
 
 				Context("gateway service account", func() {
@@ -2464,6 +2540,44 @@ metadata:
 						gatewayDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
 						testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
 					})
+
+					Context("pass image pull secrets", func() {
+						pullSecretName := "test-pull-secret"
+						pullSecret := []v1.LocalObjectReference{
+							{Name: pullSecretName},
+						}
+
+						It("via global values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("global.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
+						})
+
+						It("via podTemplate values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("gateway.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
+						})
+
+						It("podTemplate values win over global", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									"global.image.pullSecret=wrong",
+									fmt.Sprintf("gateway.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							gatewayDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
+						})
+					})
 				})
 
 				Context("discovery service account", func() {
@@ -2613,6 +2727,44 @@ metadata:
 						uid := int64(10102)
 						discoveryDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
 						testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+					})
+
+					Context("pass image pull secrets", func() {
+						pullSecretName := "test-pull-secret"
+						pullSecret := []v1.LocalObjectReference{
+							{Name: pullSecretName},
+						}
+
+						It("via global values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("global.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							discoveryDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+						})
+
+						It("via podTemplate values", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									fmt.Sprintf("discovery.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							discoveryDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+						})
+
+						It("podTemplate values win over global", func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									"global.image.pullSecret=wrong",
+									fmt.Sprintf("discovery.deployment.image.pullSecret=%s", pullSecretName),
+								},
+							})
+							discoveryDeployment.Spec.Template.Spec.ImagePullSecrets = pullSecret
+							testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+						})
 					})
 				})
 

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -137,7 +137,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 		}
 
 		// fix issue where ipv6 addr cannot bind
-		out.DnsLookupFamily = envoyapi.Cluster_V4_ONLY
+		out.DnsLookupFamily = envoyapi.Cluster_AUTO
 	}
 
 	return nil


### PR DESCRIPTION
Gloomtls issue on IPv6 cluster giving no healthy upstream error.

Binding IP socket address for envoy-sidecar-config based on ipv4/ipv6 cluster. 
