### PR TITLE
Adding ipv4Only flag to bind ipv4/ipv6 addr to glooMtls envoy-sidecar

### DIFF
--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -621,5 +621,6 @@
 |global.glooMtls.sdsResources.limits.cpu|string||amount of CPUs|
 |global.glooMtls.sdsResources.requests.memory|string||amount of memory|
 |global.glooMtls.sdsResources.requests.cpu|string||amount of CPUs|
+|global.glooMtls.ipv4Only|bool|true|This field if set false will bind the IPv6 address '::' on envoy-sidecar-config.|
 |global.istioSDS.enabled|bool|false||
 |global.istioSDS.customSidecars[]|interface||Override the default Istio sidecar in gateway-proxy with a custom container. Ignored if IstioSDS.enabled is false|

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.5-OPENET"
+	chart.Version = "1.5.6-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.global.glooMtls.enabled }}
 ---
+{{- $bindAddr := ternary "0.0.0.0" "::" .Values.global.glooMtls.ipv4Only | quote -}}
 # config_map
 apiVersion: v1
 kind: ConfigMap
@@ -17,7 +18,7 @@ data:
     static_resources:
       listeners:
       - name: envoy_xds_mtls_listener
-        address: { socket_address: { address: "0.0.0.0", port_value: {{ .Values.gloo.deployment.xdsPort }} } }
+        address: { socket_address: { address: {{ $bindAddr }}, port_value: {{ .Values.gloo.deployment.xdsPort }} } }
         filter_chains:
         - filters:
           - name: envoy.filters.network.tcp_proxy
@@ -47,7 +48,7 @@ data:
                       - envoy_grpc:
                           cluster_name: gloo_sds
       - name: envoy_rest_xds_mtls_listener
-        address: { socket_address: { address: "0.0.0.0", port_value: {{ .Values.gloo.deployment.restXdsPort }} } }
+        address: { socket_address: { address: {{ $bindAddr }}, port_value: {{ .Values.gloo.deployment.restXdsPort }} } }
         filter_chains:
         - filters:
           - name: envoy.filters.network.tcp_proxy


### PR DESCRIPTION
# Description

Binding ipv4/ipv6 address to glooMtls envoy-sidecar config based on 'ipv4Only' flag.
If global.glooMtls.ipv4Only is disbaled, it will bind :: to envoy-sidecar restXds and xds listeners.

This bug fixes ... \ This new feature can be used to ...

# Context

Issue: gloo pods are not showing READY while on ipv6 k8s cluster.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works