### PR TITLE
Adding ipv4Only default value

### DIFF
--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -107,7 +107,7 @@ func generateChartYaml(version string) error {
 		return err
 	}
 
-	chart.Version = "1.5.6-OPENET"
+	chart.Version = "1.5.7-OPENET"
 
 	return writeYaml(&chart, chartOutput)
 }

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -172,5 +172,6 @@ global:
     envoy:
       image:
         repository: gloo-envoy-wrapper
+    ipv4Only: true
   istioSDS:
     enabled: false


### PR DESCRIPTION
# Description

Binding ipv4/ipv6 address to glooMtls envoy-sidecar config based on 'ipv4Only' flag.
If global.glooMtls.ipv4Only is disbaled, it will bind :: to envoy-sidecar restXds and xds listeners.

This bug fixes ... \ This new feature can be used to ...

# Context

Issue: gloo pods are not showing READY while on ipv6 k8s cluster.


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works